### PR TITLE
Use `ConstPtr`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,9 @@ jobs:
           - 8.8.4
           - 8.10.7
           - 9.0.2
-          - 9.2.6
+          - 9.2.7
           - 9.4.4
+          - 9.6.1
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v19

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,8 @@
 packages:
   rustls
   http-client-rustls
+
+if impl(ghc >= 9.6)
+  allow-newer: *:*
+  package rustls
+    flags: -derive-storable-plugin

--- a/rustls/rustls.cabal
+++ b/rustls/rustls.cabal
@@ -27,7 +27,7 @@ source-repository head
 flag derive-storable-plugin
   description: Use derive-storable-plugin
   default: True
-  manual: True
+  manual: False
 
 common commons
   default-language: Haskell2010
@@ -47,7 +47,7 @@ library
   build-depends:
       base >= 4.12 && < 5
     , bytestring >= 0.10 && < 0.12
-    , text ^>= 1.2 || ^>= 2.0
+    , text ^>= 2.0.1
     , derive-storable ^>= 0.3
     , transformers >= 0.5.6 && < 0.7
     , resourcet ^>= 1.2 || ^>= 1.3

--- a/rustls/src/Rustls/Internal/FFI.hs
+++ b/rustls/src/Rustls/Internal/FFI.hs
@@ -4,7 +4,10 @@
 
 -- | Internal module, not subject to PVP.
 module Rustls.Internal.FFI
-  ( -- * Client
+  ( ConstPtr (..),
+    ConstCString,
+
+    -- * Client
 
     -- ** Config
     ClientConfig,
@@ -56,15 +59,17 @@ module Rustls.Internal.FFI
     connectionFree,
 
     -- ** Read/write
-    ReadWriteCallback,
-    mkReadWriteCallback,
 
     -- *** Read
+    ReadCallback,
+    mkReadCallback,
     connectionWantsRead,
     connectionRead,
     connectionReadTls,
 
     -- *** Write
+    WriteCallback,
+    mkWriteCallback,
     connectionWantsWrite,
     connectionWrite,
     connectionWriteTls,
@@ -137,6 +142,15 @@ import Foreign.C
 import Foreign.Storable.Generic
 import GHC.Generics (Generic)
 
+#if MIN_VERSION_base(4,18,0)
+import Foreign.C.ConstPtr
+#else
+newtype ConstPtr a = ConstPtr {unConstPtr :: Ptr a}
+  deriving newtype (Show, Eq, Storable)
+#endif
+
+type ConstCString = ConstPtr CChar
+
 -- Misc
 
 data {-# CTYPE "rustls.h" "rustls_str" #-} Str = Str CString CSize
@@ -185,9 +199,9 @@ data {-# CTYPE "rustls.h" "rustls_client_config_builder" #-} ClientConfigBuilder
 
 foreign import capi unsafe "rustls.h rustls_client_config_builder_new_custom"
   clientConfigBuilderNewCustom ::
-    Ptr (Ptr SupportedCipherSuite) ->
+    ConstPtr (ConstPtr SupportedCipherSuite) ->
     CSize ->
-    Ptr TLSVersion ->
+    ConstPtr TLSVersion ->
     CSize ->
     Ptr (Ptr ClientConfigBuilder) ->
     IO Result
@@ -196,21 +210,21 @@ foreign import capi unsafe "rustls.h rustls_client_config_builder_free"
   clientConfigBuilderFree :: Ptr ClientConfigBuilder -> IO ()
 
 foreign import capi unsafe "rustls.h rustls_client_config_builder_build"
-  clientConfigBuilderBuild :: Ptr ClientConfigBuilder -> IO (Ptr ClientConfig)
+  clientConfigBuilderBuild :: Ptr ClientConfigBuilder -> IO (ConstPtr ClientConfig)
 
 foreign import capi unsafe "rustls.h &rustls_client_config_free"
   clientConfigFree :: FinalizerPtr ClientConfig
 
 foreign import capi unsafe "rustls.h rustls_client_connection_new"
   clientConnectionNew ::
-    Ptr ClientConfig ->
+    ConstPtr ClientConfig ->
     -- | Hostname.
-    CString ->
+    ConstCString ->
     Ptr (Ptr Connection) ->
     IO Result
 
 foreign import capi unsafe "rustls.h rustls_client_config_builder_load_roots_from_file"
-  clientConfigBuilderLoadRootsFromFile :: Ptr ClientConfigBuilder -> CString -> IO Result
+  clientConfigBuilderLoadRootsFromFile :: Ptr ClientConfigBuilder -> ConstCString -> IO Result
 
 data {-# CTYPE "rustls.h" "rustls_root_cert_store" #-} RootCertStore
 
@@ -218,22 +232,24 @@ foreign import capi unsafe "rustls.h rustls_root_cert_store_new"
   rootCertStoreNew :: IO (Ptr RootCertStore)
 
 foreign import capi unsafe "rustls.h rustls_root_cert_store_add_pem"
-  rootCertStoreAddPEM :: Ptr RootCertStore -> Ptr Word8 -> CSize -> CBool -> IO Result
+  rootCertStoreAddPEM :: Ptr RootCertStore -> ConstPtr Word8 -> CSize -> CBool -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_root_cert_store_free"
   rootCertStoreFree :: Ptr RootCertStore -> IO ()
 
 foreign import capi unsafe "rustls.h rustls_client_config_builder_use_roots"
-  clientConfigBuilderUseRoots :: Ptr ClientConfigBuilder -> Ptr RootCertStore -> IO Result
+  clientConfigBuilderUseRoots :: Ptr ClientConfigBuilder -> ConstPtr RootCertStore -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_client_config_builder_set_alpn_protocols"
-  clientConfigBuilderSetALPNProtocols :: Ptr ClientConfigBuilder -> Ptr SliceBytes -> CSize -> IO Result
+  clientConfigBuilderSetALPNProtocols ::
+    Ptr ClientConfigBuilder -> ConstPtr SliceBytes -> CSize -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_client_config_builder_set_enable_sni"
   clientConfigBuilderSetEnableSNI :: Ptr ClientConfigBuilder -> CBool -> IO ()
 
 foreign import capi unsafe "rustls.h rustls_client_config_builder_set_certified_key"
-  clientConfigBuilderSetCertifiedKey :: Ptr ClientConfigBuilder -> Ptr (Ptr CertifiedKey) -> CSize -> IO Result
+  clientConfigBuilderSetCertifiedKey ::
+    Ptr ClientConfigBuilder -> ConstPtr (ConstPtr CertifiedKey) -> CSize -> IO Result
 
 -- TODO add callback-based cert validation?
 
@@ -244,9 +260,9 @@ data {-# CTYPE "rustls.h" "rustls_server_config_builder" #-} ServerConfigBuilder
 
 foreign import capi unsafe "rustls.h rustls_server_config_builder_new_custom"
   serverConfigBuilderNewCustom ::
-    Ptr (Ptr SupportedCipherSuite) ->
+    ConstPtr (ConstPtr SupportedCipherSuite) ->
     CSize ->
-    Ptr TLSVersion ->
+    ConstPtr TLSVersion ->
     CSize ->
     Ptr (Ptr ServerConfigBuilder) ->
     IO Result
@@ -255,44 +271,49 @@ foreign import capi unsafe "rustls.h rustls_server_config_builder_free"
   serverConfigBuilderFree :: Ptr ServerConfigBuilder -> IO ()
 
 foreign import capi unsafe "rustls.h rustls_server_config_builder_build"
-  serverConfigBuilderBuild :: Ptr ServerConfigBuilder -> IO (Ptr ServerConfig)
+  serverConfigBuilderBuild :: Ptr ServerConfigBuilder -> IO (ConstPtr ServerConfig)
 
 foreign import capi unsafe "rustls.h &rustls_server_config_free"
   serverConfigFree :: FinalizerPtr ServerConfig
 
 foreign import capi unsafe "rustls.h rustls_server_connection_new"
-  serverConnectionNew :: Ptr ServerConfig -> Ptr (Ptr Connection) -> IO Result
+  serverConnectionNew :: ConstPtr ServerConfig -> Ptr (Ptr Connection) -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_server_config_builder_set_alpn_protocols"
-  serverConfigBuilderSetALPNProtocols :: Ptr ServerConfigBuilder -> Ptr SliceBytes -> CSize -> IO Result
+  serverConfigBuilderSetALPNProtocols ::
+    Ptr ServerConfigBuilder -> ConstPtr SliceBytes -> CSize -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_server_config_builder_set_ignore_client_order"
   serverConfigBuilderSetIgnoreClientOrder :: Ptr ServerConfigBuilder -> CBool -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_server_config_builder_set_certified_keys"
-  serverConfigBuilderSetCertifiedKeys :: Ptr ServerConfigBuilder -> Ptr (Ptr CertifiedKey) -> CSize -> IO Result
+  serverConfigBuilderSetCertifiedKeys ::
+    Ptr ServerConfigBuilder -> ConstPtr (ConstPtr CertifiedKey) -> CSize -> IO Result
 
 data {-# CTYPE "rustls.h" "rustls_client_cert_verifier" #-} ClientCertVerifier
 
 foreign import capi unsafe "rustls.h rustls_client_cert_verifier_new"
-  clientCertVerifierNew :: Ptr RootCertStore -> IO (Ptr ClientCertVerifier)
+  clientCertVerifierNew :: ConstPtr RootCertStore -> IO (ConstPtr ClientCertVerifier)
 
 foreign import capi unsafe "rustls.h rustls_client_cert_verifier_free"
-  clientCertVerifierFree :: Ptr ClientCertVerifier -> IO ()
+  clientCertVerifierFree :: ConstPtr ClientCertVerifier -> IO ()
 
 foreign import capi unsafe "rustls.h rustls_server_config_builder_set_client_verifier"
-  serverConfigBuilderSetClientVerifier :: Ptr ServerConfigBuilder -> Ptr ClientCertVerifier -> IO ()
+  serverConfigBuilderSetClientVerifier ::
+    Ptr ServerConfigBuilder -> ConstPtr ClientCertVerifier -> IO ()
 
 data {-# CTYPE "rustls.h" "rustls_client_cert_verifier_optional" #-} ClientCertVerifierOptional
 
 foreign import capi unsafe "rustls.h rustls_client_cert_verifier_optional_new"
-  clientCertVerifierOptionalNew :: Ptr RootCertStore -> IO (Ptr ClientCertVerifierOptional)
+  clientCertVerifierOptionalNew ::
+    ConstPtr RootCertStore -> IO (ConstPtr ClientCertVerifierOptional)
 
 foreign import capi unsafe "rustls.h rustls_client_cert_verifier_optional_free"
-  clientCertVerifierOptionalFree :: Ptr ClientCertVerifierOptional -> IO ()
+  clientCertVerifierOptionalFree :: ConstPtr ClientCertVerifierOptional -> IO ()
 
 foreign import capi unsafe "rustls.h rustls_server_config_builder_set_client_verifier_optional"
-  serverConfigBuilderSetClientVerifierOptional :: Ptr ServerConfigBuilder -> Ptr ClientCertVerifierOptional -> IO ()
+  serverConfigBuilderSetClientVerifierOptional ::
+    Ptr ServerConfigBuilder -> ConstPtr ClientCertVerifierOptional -> IO ()
 
 -- add custom session persistence functions?
 
@@ -303,7 +324,7 @@ data {-# CTYPE "rustls.h" "rustls_connection" #-} Connection
 foreign import capi unsafe "rustls.h rustls_connection_free"
   connectionFree :: Ptr Connection -> IO ()
 
-type LogCallback = Ptr Userdata -> Ptr LogParams -> IO ()
+type LogCallback = Ptr Userdata -> ConstPtr LogParams -> IO ()
 
 foreign import ccall "wrapper"
   mkLogCallback :: LogCallback -> IO (FunPtr LogCallback)
@@ -323,53 +344,56 @@ foreign import capi unsafe "rustls.h rustls_connection_set_log_callback"
   connectionSetLogCallback :: Ptr Connection -> FunPtr LogCallback -> IO ()
 
 foreign import capi unsafe "rustls.h rustls_connection_is_handshaking"
-  connectionIsHandshaking :: Ptr Connection -> IO CBool
+  connectionIsHandshaking :: ConstPtr Connection -> IO CBool
 
 foreign import capi unsafe "rustls.h rustls_connection_get_alpn_protocol"
-  connectionGetALPNProtocol :: Ptr Connection -> Ptr (Ptr Word8) -> Ptr CSize -> IO ()
+  connectionGetALPNProtocol :: ConstPtr Connection -> Ptr (ConstPtr Word8) -> Ptr CSize -> IO ()
 
 foreign import capi unsafe "rustls.h rustls_connection_get_protocol_version"
-  connectionGetProtocolVersion :: Ptr Connection -> IO TLSVersion
+  connectionGetProtocolVersion :: ConstPtr Connection -> IO TLSVersion
 
 foreign import capi unsafe "rustls.h rustls_connection_get_negotiated_ciphersuite"
-  connectionGetNegotiatedCipherSuite :: Ptr Connection -> IO (Ptr SupportedCipherSuite)
+  connectionGetNegotiatedCipherSuite :: ConstPtr Connection -> IO (ConstPtr SupportedCipherSuite)
 
 foreign import capi unsafe "rustls.h rustls_server_connection_get_sni_hostname"
-  serverConnectionGetSNIHostname :: Ptr Connection -> Ptr Word8 -> CSize -> Ptr CSize -> IO Result
+  serverConnectionGetSNIHostname :: ConstPtr Connection -> Ptr Word8 -> CSize -> Ptr CSize -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_connection_get_peer_certificate"
-  connectionGetPeerCertificate :: Ptr Connection -> CSize -> IO (Ptr Certificate)
-
--- connection read/write
-
-type ReadWriteCallback = Ptr Userdata -> Ptr Word8 -> CSize -> Ptr CSize -> IO IOResult
-
-foreign import ccall "wrapper"
-  mkReadWriteCallback :: ReadWriteCallback -> IO (FunPtr ReadWriteCallback)
+  connectionGetPeerCertificate :: ConstPtr Connection -> CSize -> IO (ConstPtr Certificate)
 
 -- connection read
 
+type ReadCallback = Ptr Userdata -> Ptr Word8 -> CSize -> Ptr CSize -> IO IOResult
+
+foreign import ccall "wrapper"
+  mkReadCallback :: ReadCallback -> IO (FunPtr ReadCallback)
+
 foreign import capi "rustls.h rustls_connection_read_tls"
   connectionReadTls ::
-    Ptr Connection -> FunPtr ReadWriteCallback -> Ptr Userdata -> Ptr CSize -> IO IOResult
+    Ptr Connection -> FunPtr ReadCallback -> Ptr Userdata -> Ptr CSize -> IO IOResult
 
 foreign import capi "rustls.h rustls_connection_read"
   connectionRead :: Ptr Connection -> Ptr Word8 -> CSize -> Ptr CSize -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_connection_wants_read"
-  connectionWantsRead :: Ptr Connection -> IO CBool
+  connectionWantsRead :: ConstPtr Connection -> IO CBool
 
 -- connection write
 
+type WriteCallback = Ptr Userdata -> ConstPtr Word8 -> CSize -> Ptr CSize -> IO IOResult
+
+foreign import ccall "wrapper"
+  mkWriteCallback :: WriteCallback -> IO (FunPtr WriteCallback)
+
 foreign import capi "rustls.h rustls_connection_write_tls"
   connectionWriteTls ::
-    Ptr Connection -> FunPtr ReadWriteCallback -> Ptr Userdata -> Ptr CSize -> IO IOResult
+    Ptr Connection -> FunPtr WriteCallback -> Ptr Userdata -> Ptr CSize -> IO IOResult
 
 foreign import capi "rustls.h rustls_connection_write"
   connectionWrite :: Ptr Connection -> Ptr Word8 -> CSize -> Ptr CSize -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_connection_wants_write"
-  connectionWantsWrite :: Ptr Connection -> IO CBool
+  connectionWantsWrite :: ConstPtr Connection -> IO CBool
 
 -- misc
 
@@ -386,37 +410,38 @@ foreign import capi unsafe "rustls.h rustls_connection_set_buffer_limit"
 data {-# CTYPE "rustls.h" "rustls_certified_key" #-} CertifiedKey
 
 foreign import capi unsafe "rustls.h rustls_certified_key_build"
-  certifiedKeyBuild :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> Ptr (Ptr CertifiedKey) -> IO Result
+  certifiedKeyBuild ::
+    ConstPtr Word8 -> CSize -> ConstPtr Word8 -> CSize -> Ptr (ConstPtr CertifiedKey) -> IO Result
 
 foreign import capi unsafe "rustls.h rustls_certified_key_free"
-  certifiedKeyFree :: Ptr CertifiedKey -> IO ()
+  certifiedKeyFree :: ConstPtr CertifiedKey -> IO ()
 
 data {-# CTYPE "rustls.h" "rustls_certificate" #-} Certificate
 
 foreign import capi unsafe "rustls.h rustls_certificate_get_der"
-  certificateGetDER :: Ptr Certificate -> Ptr (Ptr Word8) -> Ptr CSize -> IO Result
+  certificateGetDER :: ConstPtr Certificate -> Ptr (ConstPtr Word8) -> Ptr CSize -> IO Result
 
 -- TLS params
 
 data {-# CTYPE "rustls.h" "rustls_supported_ciphersuite" #-} SupportedCipherSuite
 
 foreign import capi "rustls.h value RUSTLS_ALL_CIPHER_SUITES"
-  allCipherSuites :: Ptr (Ptr SupportedCipherSuite)
+  allCipherSuites :: ConstPtr (Ptr SupportedCipherSuite)
 
 foreign import capi "rustls.h value RUSTLS_ALL_CIPHER_SUITES_LEN"
   allCipherSuitesLen :: CSize
 
 foreign import capi "rustls.h value RUSTLS_DEFAULT_CIPHER_SUITES"
-  defaultCipherSuites :: Ptr (Ptr SupportedCipherSuite)
+  defaultCipherSuites :: ConstPtr (ConstPtr SupportedCipherSuite)
 
 foreign import capi "rustls.h value RUSTLS_DEFAULT_CIPHER_SUITES_LEN"
   defaultCipherSuitesLen :: CSize
 
 foreign import capi unsafe "rustls.h rustls_supported_ciphersuite_get_suite"
-  supportedCipherSuiteGetSuite :: Ptr SupportedCipherSuite -> Word16
+  supportedCipherSuiteGetSuite :: ConstPtr SupportedCipherSuite -> Word16
 
 foreign import capi unsafe "hs_rustls.h hs_rustls_supported_ciphersuite_get_name"
-  hsSupportedCipherSuiteGetName :: Ptr SupportedCipherSuite -> Ptr Str -> IO ()
+  hsSupportedCipherSuiteGetName :: ConstPtr SupportedCipherSuite -> Ptr Str -> IO ()
 
 -- | A TLS protocol version supported by Rustls.
 newtype {-# CTYPE "stdint.h" "uint16_t" #-} TLSVersion = TLSVersion
@@ -430,13 +455,13 @@ pattern TLS12 = TLSVersion 0x0303
 pattern TLS13 = TLSVersion 0x0304
 
 foreign import capi "rustls.h value RUSTLS_ALL_VERSIONS"
-  allVersions :: Ptr TLSVersion
+  allVersions :: ConstPtr TLSVersion
 
 foreign import capi "rustls.h value RUSTLS_ALL_VERSIONS_LEN"
   allVersionsLen :: CSize
 
 foreign import capi "rustls.h value RUSTLS_DEFAULT_VERSIONS"
-  defaultVersions :: Ptr TLSVersion
+  defaultVersions :: ConstPtr TLSVersion
 
 foreign import capi "rustls.h value RUSTLS_DEFAULT_VERSIONS_LEN"
   defaultVersionsLen :: CSize


### PR DESCRIPTION
Use `ConstPtr` from GHC 9.6.1.

With this, all of the existing warnings about incompatible pointer types vanish.